### PR TITLE
Support laying out children with parents

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -160,11 +160,9 @@ class Layout {
 
     const elk = new ELK();
     const graph = makeGraph(nodes, edges, options);
-
+    graph['layoutOptions'] = options.elk
     elk
-      .layout(graph, {
-        layoutOptions: options.elk,
-      })
+      .layout(graph)
       .then(() => {
         nodes
           .filter((n) => !n.isParent())


### PR DESCRIPTION
ELK recommends that you set `org.eclipse.elk.hierarchyHandling` to `INCLUDE_CHILDREN`, in order to lay out graphs that have edges between nodes inside compound nodes to other nodes.

Currently, if I do that, I get this error:

```
Uncaught (in promise) Error: org.eclipse.elk.core.UnsupportedGraphException: The source or the target of edge ElkEdge "edge:96" ElkNode "1:8" (-30.5,-16 | 61,32) -> ElkNode "1:2" (-27,-16 | 54,32) could not be found. This usually happens when an edge connects a node laid out by ELK Layered to a node in another level of hierarchy laid out by either another instance of ELK Layered or another layout algorithm alltogether. The former can be solved by setting the hierarchyHandling option to INCLUDE_CHILDREN.
```

However, I noticed that if instead of passing in the options as an argument to the layout algorithm, I set them on the graph, then it seems to work fine.

This PR supersedes https://github.com/cytoscape/cytoscape.js-elk/pull/31 to support layouts with these complex edges. That PR moved the edges inside the parents, which worked to properly layout graphs inside the compound nodes, but didn't layout with regard to edges from inside to outside. Using the `INCLUDE_CHILDREN` option along with this PR gives me a proper total layout.